### PR TITLE
[FRE-391] wstETH Neutron → wstETH

### DIFF
--- a/src/context/assets.tsx
+++ b/src/context/assets.tsx
@@ -50,6 +50,7 @@ function getAssetSymbolSuffix(originDenom: string, originChainName: string) {
       return ".sif";
     case "Gravity Bridge":
       return ".grv";
+    case "Neutron":
     case "Noble":
       return "";
     default:


### PR DESCRIPTION
## Description

This PR adds a hotfix to replace "wstETH Neutron" to "wstETH" on the Neutron chain asset selection.

## Screenshots/Videos

<table>
<tr>
<td>

**Before**

https://github.com/skip-mev/ibc-dot-fun/assets/8220954/e4b87234-579e-441c-9653-d67b0c4a2f20


</td>
<td>

**After**

https://github.com/skip-mev/ibc-dot-fun/assets/8220954/83b74a71-4df1-4489-b292-00dcea1e593f

</td>
</tr>
</table>
