### PR TITLE
Add CORS header baggage

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const corsOptions = {
   "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, solana-client, sentry-trace",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, solana-client, sentry-trace, baggage",
 };
 
 const cleanOrigin = (str: string) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b8a4a83d-094c-4b7b-ba6b-7df9bfa71cf5)

There's another CORS header I need to allow for sentry

sentry documentation also outlines this:

https://docs.sentry.io/platforms/java/guides/spring/tracing/trace-propagation/dealing-with-cors-issues/