### PR TITLE
[FRE-1953] Add Amplitude tracking

### DIFF
--- a/.changeset/amplitude-tracking.md
+++ b/.changeset/amplitude-tracking.md
@@ -1,0 +1,5 @@
+---
+skip-go-app: patch
+---
+
+Add amplitude analytics initialization and event tracking for share, docs, and help buttons.

--- a/src/components/DiscordButton.tsx
+++ b/src/components/DiscordButton.tsx
@@ -4,12 +4,14 @@ import ArrowIcon from "./ArrowIcon";
 import styles from "./button.module.css";
 import cosmosStyles from "./cosmos/cosmos.module.css";
 import { ThinArrowIcon } from "./cosmos/ThinArrowIcon";
+import { track } from "@/lib/amplitude";
 
 const DiscordButton = () => (
   <a
     className={`${isCosmosDomain ? cosmosStyles.cosmosbutton : styles.skipbutton} font-diatype`}
     href={isCosmosDomain ? "https://discord.gg/interchain" : "https://skip.build/discord"}
     target="_blank"
+    onClick={() => track("connect eco row: help button - clicked")}
   >
     Need Help?
     {isCosmosDomain ? <ThinArrowIcon /> : <ArrowIcon />}

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -1,3 +1,5 @@
+import { track } from "@/lib/amplitude";
+
 export const Help = () => {
   return (
     <div className="fixed bottom-2 right-2 rounded-full bg-white px-4 py-2 shadow-xl">
@@ -8,6 +10,7 @@ export const Help = () => {
           target="_blank"
           rel="noreferrer"
           className="text-blue-500 hover:text-blue-600 hover:underline"
+          onClick={() => track("connect eco row: help button - clicked")}
         >
           Discord
         </a>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { isCosmosDomain } from "@/pages";
+import { track } from "@/lib/amplitude";
 
 import styles from "./button.module.css";
 import cosmosStyles from "./cosmos/cosmos.module.css";
@@ -10,6 +11,7 @@ const ShareButton = ({ onClick }: { onClick?: () => void }) => {
 
   const handleOnClick = () => {
     onClick?.();
+    track("connect eco row: share button - clicked");
     setIsShowingCopyToClipboardFeedback(true);
     setTimeout(() => {
       setIsShowingCopyToClipboardFeedback(false);

--- a/src/components/WidgetButton.tsx
+++ b/src/components/WidgetButton.tsx
@@ -1,11 +1,13 @@
 import ArrowIcon from "./ArrowIcon";
 import styles from "./button.module.css";
+import { track } from "@/lib/amplitude";
 
 const WidgetButton = () => (
   <a
     className={`${styles.skipbutton} ${styles.widgetButton} font-diatype`}
     href="https://docs.skip.build/go"
     target="_blank"
+    onClick={() => track("connect eco row: docs button - clicked")}
   >
     Build with Skip:Go
     <ArrowIcon />

--- a/src/lib/amplitude.ts
+++ b/src/lib/amplitude.ts
@@ -1,0 +1,7 @@
+import * as amplitude from '@amplitude/analytics-browser';
+
+export const initAmplitude = () => {
+  amplitude.init('14616a575f32087cf0403ab8f3ea3ce0');
+};
+
+export const track = amplitude.track;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import React from "react";
+import { initAmplitude } from "@/lib/amplitude";
 
 import { DefaultSeo } from "@/components/DefaultSeo";
 
@@ -11,6 +12,10 @@ export const isCosmosDomain = process.env.NEXT_PUBLIC_COSMOS_DOMAIN === "true";
 
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient());
+
+  React.useEffect(() => {
+    initAmplitude();
+  }, []);
 
   isCosmosDomain ? require("../styles/cosmosGlobals.css") : require("../styles/globals.css");
 


### PR DESCRIPTION
## Summary
- initialize Amplitude analytics
- track Share, Docs, and Help button interactions
- document changes with a changeset

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_6859953094388329aa770b0343cfbda4